### PR TITLE
Update 3-print_remaining_days.c

### DIFF
--- a/0x03-debugging/3-print_remaining_days.c
+++ b/0x03-debugging/3-print_remaining_days.c
@@ -12,7 +12,7 @@
 
 void print_remaining_days(int month, int day, int year)
 {
-	if ((year % 100 == 0 || year % 400 == 0) && !(year % 4 == 0))
+	if ((year % 100 == 0 && year % 400 == 0) || (year % 4 == 0))
 	{
 		if (month > 2 && day >= 60)
 		{


### PR DESCRIPTION
For a year to be termed leap year, (It has to divided by 100 and also by 400 without a remainder) or (be divided by 4 without a remainder)